### PR TITLE
endExclusive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ release:
 	gh release create v$(call version_fn) && \
 	make deploy
 
-.PHONY: tests
-tests:
+.PHONY: test
+test:
 	mvn test -Dmaven.plugin.validation=VERBOSE
 
 .PHONY: start-mongodb
@@ -190,7 +190,7 @@ help:
 	@echo
 	@echo -e "Please use \`$(YELLOW)make <target>$(RESET)', where $(YELLOW)<target>$(RESET) is one of:"
 	@echo -e "  $(BLUE)git-pull$(RESET)                  - to pull git changes from the main branch ( + update the develop branch)"
-	@echo -e "  $(BLUE)tests$(RESET)                     - to test the project"
+	@echo -e "  $(BLUE)test$(RESET)                     - to test the project"
 	@echo -e "  $(BLUE)clean$(RESET)                     - to remove generated files"
 	@echo -e "  $(BLUE)compile-protocol-buffers$(RESET)  - to compile all .proto files"
 	@echo -e "  $(BLUE)install-client$(RESET)            - to install the client code in the local maven repository"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ CLIENT_SRC=$(shell find client/src/ -type f)
 COMMON_SRC=$(shell find common/src/ -type f)
 version_fn = $(shell cat .make/.version 2>/dev/null)
 
+.SECONDARY:
+.DELETE_ON_ERROR:
+
+RED=\033[1;31m
+GREEN=\033[1;32m
+YELLOW=\033[1;33m
+BLUE=\033[1;34m
+RESET=\033[0m
+
 .make:
 	mkdir -p .make
 
@@ -177,36 +186,36 @@ browse-registry:
 
 .PHONY: help
 help:
-	@echo "make-tools for $(TAG)"
+	@echo -e "make-tools for $(GREEN)$(TAG)$(RESET)"
 	@echo
-	@echo "Please use \`make <target>', where <target> is one of:"
-	@echo "  git-pull                  - to pull git changes from the main branch ( + update the develop branch)"
-	@echo "  tests                     - to test the project"
-	@echo "  clean                     - to remove generated files"
-	@echo "  compile-protocol-buffers  - to compile all .proto files"
-	@echo "  install-client            - to install the client code in the local maven repository"
+	@echo -e "Please use \`$(YELLOW)make <target>$(RESET)', where $(YELLOW)<target>$(RESET) is one of:"
+	@echo -e "  $(BLUE)git-pull$(RESET)                  - to pull git changes from the main branch ( + update the develop branch)"
+	@echo -e "  $(BLUE)tests$(RESET)                     - to test the project"
+	@echo -e "  $(BLUE)clean$(RESET)                     - to remove generated files"
+	@echo -e "  $(BLUE)compile-protocol-buffers$(RESET)  - to compile all .proto files"
+	@echo -e "  $(BLUE)install-client$(RESET)            - to install the client code in the local maven repository"
 	@echo
-	@echo "  build                     - to test and build the project"
-	@echo "  build-server              - to test and build just the server"
-	@echo "  build-client              - to test and build just the client"
+	@echo -e "  $(BLUE)build$(RESET)                     - to test and build the project"
+	@echo -e "  $(BLUE)build-server$(RESET)              - to test and build just the server"
+	@echo -e "  $(BLUE)build-client$(RESET)              - to test and build just the client"
 	@echo
-	@echo "  start-mongodb             - to start a local mongodb"
-	@echo "  run-server-with-auth      - to start the server app with authorization on"
-	@echo "  run-server-without-auth   - to start the server app with authorization off"
-	@echo "  run-env                   - to run the annorepo env command"
-	@echo "  set-log-level-debug       - to set the log level of the server app to DEBUG"
-	@echo "  set-log-level-info        - to set the log level of the server app to INFO"
+	@echo -e "  $(BLUE)start-mongodb$(RESET)             - to start a local mongodb"
+	@echo -e "  $(BLUE)run-server-with-auth$(RESET)      - to start the server app with authorization on"
+	@echo -e "  $(BLUE)run-server-without-auth$(RESET)   - to start the server app with authorization off"
+	@echo -e "  $(BLUE)run-env$(RESET)                   - to run the annorepo env command"
+	@echo -e "  $(BLUE)set-log-level-debug$(RESET)       - to set the log level of the server app to DEBUG"
+	@echo -e "  $(BLUE)set-log-level-info$(RESET)        - to set the log level of the server app to INFO"
 	@echo
-	@echo "  docker-run                - to start the server app in docker"
-	@echo "  docker-stop               - to stop the server app in docker"
+	@echo -e "  $(BLUE)docker-run$(RESET)                - to start the server app in docker"
+	@echo -e "  $(BLUE)docker-stop$(RESET)               - to stop the server app in docker"
 	@echo
-	@echo "  docker-image              - to build the docker image of the app (¹)"
-	@echo "  push                      - to push the linux/amd64 docker image to registry.diginfra.net (¹)"
-	@echo "  browse-registry           - to open the registry.diginfra.net registry browser"
+	@echo -e "  $(BLUE)docker-image$(RESET)              - to build the docker image of the app (¹)"
+	@echo -e "  $(BLUE)push$(RESET)                      - to push the linux/amd64 docker image to registry.diginfra.net (¹)"
+	@echo -e "  $(BLUE)browse-registry$(RESET)           - to open the registry.diginfra.net registry browser"
 	@echo
-	@echo "  version-update            - to update the project version"
-	@echo "  dokka                     - to generate dokka html"
-	@echo "  deploy                    - to deploy annorepo-client and annorepo-common"
-	@#echo "  release                   - to create a new release on github + deploy the new client"
+	@echo -e "  $(BLUE)version-update$(RESET)            - to update the project version"
+	@echo -e "  $(BLUE)dokka$(RESET)                     - to generate dokka html"
+	@echo -e "  $(BLUE)deploy$(RESET)                    - to deploy annorepo-client and annorepo-common"
+	@#echo -e "  $(BLUE)release$(RESET)                   - to create a new release on github + deploy the new client"
 	@echo
 	@echo "¹) for test purposes only, the public docker image is built by github actions upon a release"

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>io.github.knaw-huc</groupId>
         <artifactId>annorepo</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.0</version>
     </parent>
 
     <dependencyManagement>

--- a/client/readme.md
+++ b/client/readme.md
@@ -14,7 +14,7 @@ Add the following to your `pom.xml`
 <dependency>
     <groupId>io.github.knaw-huc</groupId>
     <artifactId>annorepo-client</artifactId>
-    <version>0.8.1</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.knaw-huc</groupId>
         <artifactId>annorepo</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.0</version>
     </parent>
 
     <artifactId>annorepo-common</artifactId>
-    <version>0.8.1</version>
+    <version>0.9.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Shared libraries/classes/methods for AnnoRepo</description>

--- a/config-with-auth.yml
+++ b/config-with-auth.yml
@@ -26,6 +26,7 @@ databaseName: ${AR_DB_NAME:-annorepo}
 
 rangeSelectorType: ${AR_RANGE_SELECTOR_TYPE:-TextPositionSelector}
 rangeTargetType: ${AR_RANGE_TARGET_TYPE:-NormalText}
+endExclusive: ${AR_END_EXCLUSIVE:-true}
 
 logging:
   level: INFO

--- a/config-without-auth.yml
+++ b/config-without-auth.yml
@@ -26,6 +26,7 @@ databaseName: ${AR_DB_NAME:-annorepo}
 
 rangeSelectorType: ${AR_RANGE_SELECTOR_TYPE:-TextPositionSelector}
 rangeTargetType: ${AR_RANGE_TARGET_TYPE:-Text}
+endExclusive: ${AR_END_EXCLUSIVE:-true}
 
 logging:
   level: INFO

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>io.github.knaw-huc</groupId>
         <artifactId>annorepo</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.0</version>
     </parent>
 
     <artifactId>annorepo-integration-test</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>0.8.1</version>
+    <version>0.9.0</version>
 
     <properties>
         <mainClass>nl.knaw.huc.annorepo.integration.IntegrationTest</mainClass>

--- a/k8s/annorepo-server/config.yml
+++ b/k8s/annorepo-server/config.yml
@@ -26,6 +26,7 @@ databaseName: ${AR_DB_NAME:-annorepo}
 
 rangeSelectorType: ${AR_RANGE_SELECTOR_TYPE:-TextPositionSelector}
 rangeTargetType: ${AR_RANGE_TARGET_TYPE:-NormalText}
+endExclusive: ${AR_END_EXCLUSIVE:-true}
 
 logging:
   level: INFO

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>io.github.knaw-huc</groupId>
     <artifactId>annorepo</artifactId>
-    <version>0.8.1</version>
+    <version>0.9.0</version>
     <packaging>pom</packaging>
 
     <name>AnnoRepo</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.github.knaw-huc</groupId>
         <artifactId>annorepo</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.0</version>
     </parent>
 
     <properties>

--- a/server/src/main/kotlin/nl/knaw/huc/annorepo/api/ARConst.kt
+++ b/server/src/main/kotlin/nl/knaw/huc/annorepo/api/ARConst.kt
@@ -14,6 +14,7 @@ object ARConst {
         AR_PRETTY_PRINT,
         AR_RANGE_SELECTOR_TYPE,
         AR_RANGE_TARGET_TYPE,
+        AR_END_EXCLUSIVE,
         AR_GRPC_HOSTNAME,
         AR_GRPC_PORT,
         AR_APPLICATION_TOKEN

--- a/server/src/main/kotlin/nl/knaw/huc/annorepo/config/AnnoRepoConfiguration.kt
+++ b/server/src/main/kotlin/nl/knaw/huc/annorepo/config/AnnoRepoConfiguration.kt
@@ -47,6 +47,11 @@ open class AnnoRepoConfiguration : JobConfiguration() {
 
     @Valid
     @NotNull
+    @JsonProperty
+    var endExclusive = true
+
+    @Valid
+    @NotNull
     @JsonProperty("swagger")
     val swaggerBundleConfiguration = SwaggerBundleConfiguration().apply {
         resourcePackage = AboutResource::class.java.getPackage().name

--- a/server/src/main/kotlin/nl/knaw/huc/annorepo/resources/tools/AggregateStageGenerator.kt
+++ b/server/src/main/kotlin/nl/knaw/huc/annorepo/resources/tools/AggregateStageGenerator.kt
@@ -117,6 +117,14 @@ class AggregateStageGenerator(val configuration: AnnoRepoConfiguration) {
         when (rawParameters) {
             is Map<*, *> -> {
                 val rangeParameters = rangeParameters(rawParameters)
+                val fse = when (configuration.endExclusive) {
+                    true -> Filters.lt("selector.start", rangeParameters.end)
+                    false -> Filters.lte("selector.start", rangeParameters.end)
+                }
+                val fes = when (configuration.endExclusive) {
+                    true -> Filters.gt("selector.end", rangeParameters.start)
+                    false -> Filters.gte("selector.end", rangeParameters.start)
+                }
                 match(
                     Filters.elemMatch(
                         "${ANNOTATION_FIELD_PREFIX}target",
@@ -124,8 +132,8 @@ class AggregateStageGenerator(val configuration: AnnoRepoConfiguration) {
                             Filters.eq("type", configuration.rangeTargetType),
                             Filters.eq("source", rangeParameters.source),
                             Filters.eq("selector.type", configuration.rangeSelectorType),
-                            Filters.lte("selector.start", rangeParameters.end),
-                            Filters.gte("selector.end", rangeParameters.start),
+                            fse,
+                            fes,
                         )
                     )
                 )

--- a/server/src/test/kotlin/nl/knaw/huc/annorepo/resources/ContainerServiceResourceTest.kt
+++ b/server/src/test/kotlin/nl/knaw/huc/annorepo/resources/ContainerServiceResourceTest.kt
@@ -367,6 +367,7 @@ class ContainerServiceResourceTest {
             every { config.rangeSelectorType } returns "something"
             every { config.rangeTargetType } returns "Text"
             every { config.withAuthentication } returns true
+            every { config.endExclusive } returns true
             every { client.getDatabase(DATABASE_NAME) } returns mongoDatabase
             every { mongoDatabase.getCollection(CONTAINER_NAME) } returns mongoCollection
             every { mongoDatabase.listCollectionNames() } returns collectionNames

--- a/server/src/test/kotlin/nl/knaw/huc/annorepo/resources/tools/AggregateStageGeneratorTest.kt
+++ b/server/src/test/kotlin/nl/knaw/huc/annorepo/resources/tools/AggregateStageGeneratorTest.kt
@@ -273,11 +273,54 @@ class AggregateStageGeneratorTest {
     }
 
     @Test
-    fun `query functions - overlapping_with_range`() {
+    fun `query functions - overlapping_with_range - end exclusive`() {
         val selector = "rangeSelectorType"
         every { config.rangeSelectorType } returns selector
         val targetType = "Text"
         every { config.rangeTargetType } returns targetType
+        every { config.endExclusive } returns true
+
+        val asg = AggregateStageGenerator(config)
+        val source = "http://example.com/some-id"
+        val start = 200
+        val end = 300
+        val parameters = mapOf(
+            "source" to source,
+            "start" to start,
+            "end" to end
+        )
+        val stage = asg.generateStage(
+            OVERLAPPING_WITH_RANGE,
+            parameters
+        )
+        logger.info { stage }
+        val expected = """
+            { 
+                "@match": {
+                    "annotation.target" : {
+                        "@elemMatch": {
+                            "@and": [
+                                { "type": "Text"},
+                                { "source": "$source"},
+                                { "selector.type": "$selector"},
+                                { "selector.start": { "@lt": ${end.toFloat()} } },
+                                { "selector.end":   { "@gt": ${start.toFloat()} } }
+                            ]
+                        }
+                    }
+                }
+            }""".trimIndent().replace('@', '$')
+        assertThatJson(stage.json).isEqualTo(expected)
+        logger.info { stage.json }
+    }
+
+    @Test
+    fun `query functions - overlapping_with_range - end inclusive`() {
+        val selector = "rangeSelectorType"
+        every { config.rangeSelectorType } returns selector
+        val targetType = "Text"
+        every { config.rangeTargetType } returns targetType
+        every { config.endExclusive } returns false
 
         val asg = AggregateStageGenerator(config)
         val source = "http://example.com/some-id"


### PR DESCRIPTION
Make end exclusive by default for overlap queries.
Added `endExclusive` config option and `AR_END_EXCLUSIVE` environment value: set to false to interpret `end` as inclusive.